### PR TITLE
Repo rename

### DIFF
--- a/INTERESTED_DEVELOPERS.md
+++ b/INTERESTED_DEVELOPERS.md
@@ -29,7 +29,7 @@ If you want to be listed here, open a PR with your information, just order yours
   * Company/Project/Repo: https://github.com/graphql-dotnet/graphql-client
   * Reason: Interested in client/server on C# stack
 * @enisdenjo
-  * Company/Project/Repo: https://github.com/domonda, https://github.com/bhidapa, https://github.com/enisdenjo/graphql-transport-ws
+  * Company/Project/Repo: https://github.com/domonda, https://github.com/bhidapa, https://github.com/enisdenjo/graphql-ws
   * Reason: Interested in a common subscriptions spec
 * @erikwittern
   * Company/Project/Repo: https://github.com/graphql/libgraphqlparser, https://github.com/IBM/openapi-to-graphql

--- a/working-group/agendas/2020-08-25.md
+++ b/working-group/agendas/2020-08-25.md
@@ -23,7 +23,7 @@ This is an open meeting in which anyone in the GraphQL community may attend.
 | Name                     | Organization / Project         | Location
 | ------------------------ | ------------------------------ | ---------
 | Sam Parsons | PayPal | Iowa, USA
-| Denis Badurina | [graphql-transport-ws](https://github.com/enisdenjo/graphql-transport-ws) | Vienna, Austria
+| Denis Badurina | [graphql-ws](https://github.com/enisdenjo/graphql-ws) | Vienna, Austria
 | Morris Matsa | IBM | Boston, USA
 
 ## Agenda


### PR DESCRIPTION
The `graphql-transport-ws` repository has been renamed to `graphql-ws`. This PR updates the links.