### PR TITLE
Spec edits for multipart @defer @stream around content-length

### DIFF
--- a/rfcs/IncrementalDelivery.md
+++ b/rfcs/IncrementalDelivery.md
@@ -28,10 +28,11 @@ Content-Type: application/json; charset=utf-8
 -----
 ```
 * The boundary used is `-` and is passed to the client in the http response's `Content-Type` header. Note that headers can appear in both the HTTP response itself and as part of the response body. The `Content-Type` header must be sent in the HTTP response.
-* Each part of the multipart response must start with `---` and a `CRLF`
+* An initial boundary is sent marking the end of the preamble area.
+* Each part of the multipart response must end with `---` and wrapped with `CRLF`, meaning the boundary occupy it's own line.
 * Each part of the multipart response must contain a `Content-Type` header. Similar to the GraphQL specification this specification does not require a specific serialization format. For consistency and ease of notation, examples of the response are given in JSON throughout the spec.
 * After all headers, an additional `CRLF` is sent.
-* After the last part of the multipart response is sent, the terminating boundary `-----` is sent, followed by a `CRLF`
+* The last part of the multipart response, a terminating boundary `-----` is sent (inistead of a boundary), followed by a `CRLF`
 
 ## Server Implementations
 * `express-graphql`: [pull request](https://github.com/graphql/express-graphql/pull/583)

--- a/rfcs/IncrementalDelivery.md
+++ b/rfcs/IncrementalDelivery.md
@@ -27,12 +27,12 @@ Content-Type: application/json; charset=utf-8
 {"data":{"test":"Hello World"},"path":[],"hasNext":false}
 -----
 ```
-* The boundary used is `-` and is passed to the client in the http response's `Content-Type` header. Note that headers can appear in both the HTTP response itself and as part of the response body. The `Content-Type` header must be sent in the HTTP response.
+* The boundary used is - and is passed to the client in the http response's `Content-Type` header. Note that headers can appear in both the HTTP response itself and as part of the response body. The `Content-Type` header must be sent in the HTTP response.
 * An initial boundary is sent marking the end of the preamble area.
-* Each part of the multipart response must end with `---` and wrapped with `CRLF`, meaning the boundary occupy it's own line.
 * Each part of the multipart response must contain a `Content-Type` header. Similar to the GraphQL specification this specification does not require a specific serialization format. For consistency and ease of notation, examples of the response are given in JSON throughout the spec.
 * After all headers, an additional `CRLF` is sent.
-* The last part of the multipart response, a terminating boundary `-----` is sent (inistead of a boundary), followed by a `CRLF`
+* The payload is sent, followed by a `CRLF`.
+* After each payload, a boundary is sent. For the final payload, the terminating boundary of `-----` followed by a `CRLF` is sent. For all other payloads a boundary of `---` followed by a `CRFL` is sent.
 
 ## Server Implementations
 * `express-graphql`: [pull request](https://github.com/graphql/express-graphql/pull/583)

--- a/rfcs/IncrementalDelivery.md
+++ b/rfcs/IncrementalDelivery.md
@@ -19,24 +19,18 @@ An example response body will look like:
 ```
 ---
 Content-Type: application/json; charset=utf-8
-Content-Length: 45
 
 {"data":{"hello":"Hello Rob"},"hasNext":true}
-
 ---
 Content-Type: application/json; charset=utf-8
-Content-Length: 57
 
 {"data":{"test":"Hello World"},"path":[],"hasNext":false}
-
 -----
 ```
 * The boundary used is `-` and is passed to the client in the http response's `Content-Type` header. Note that headers can appear in both the HTTP response itself and as part of the response body. The `Content-Type` header must be sent in the HTTP response.
 * Each part of the multipart response must start with `---` and a `CRLF`
 * Each part of the multipart response must contain a `Content-Type` header. Similar to the GraphQL specification this specification does not require a specific serialization format. For consistency and ease of notation, examples of the response are given in JSON throughout the spec.
-* Each part of the multipart response must contain a `Content-Length` header. This should be the number of bytes of the payload of the response. It does not include the size of the headers, boundaries, or `CRLF`s used to separate the content.
 * After all headers, an additional `CRLF` is sent.
-* The payload is sent, followed by two `CRLF`s.
 * After the last part of the multipart response is sent, the terminating boundary `-----` is sent, followed by a `CRLF`
 
 ## Server Implementations

--- a/rfcs/IncrementalDelivery.md
+++ b/rfcs/IncrementalDelivery.md
@@ -27,7 +27,7 @@ Content-Type: application/json; charset=utf-8
 {"data":{"test":"Hello World"},"path":[],"hasNext":false}
 -----
 ```
-* The boundary used is - and is passed to the client in the http response's `Content-Type` header. Note that headers can appear in both the HTTP response itself and as part of the response body. The `Content-Type` header must be sent in the HTTP response.
+* The boundary used is `-` and is passed to the client in the http response's `Content-Type` header. Note that headers can appear in both the HTTP response itself and as part of the response body. The `Content-Type` header must be sent in the HTTP response.
 * An initial boundary is sent marking the end of the preamble area.
 * Each part of the multipart response must contain a `Content-Type` header. Similar to the GraphQL specification this specification does not require a specific serialization format. For consistency and ease of notation, examples of the response are given in JSON throughout the spec.
 * After all headers, an additional `CRLF` is sent.


### PR DESCRIPTION
This PR aims to amend a few things that were discovered upon implementation:

- `Content-Length` is not mentioned as a requirement from the multipart spec. The change will now reflect that the boundary is not the "start" of the part, but rather the end of the part. The first boundary being the end of the preamble. This will give clients a much more predictable "I have enough body" to then begin parsing. Rather than wait for the next boundary to flush, which as per sample implementations wouldn't flush till the next chunk was written, potentially delaying the processing of that part. This now means a client can consume chunks till a boundary, then parse.
- the empty line after a body is also not accurate per multipart spec.

This will mean we're seeing a much tighter smaller payload, and easier to consume for clients.

cc @robrichard 