### PR TITLE
Update repo to reflect recent Working Group decisions

### DIFF
--- a/INTERESTED_DEVELOPERS.md
+++ b/INTERESTED_DEVELOPERS.md
@@ -7,7 +7,7 @@ If you're interested in this spec and helping contribute to it, you can get invo
 1. Read the [Roadmap](ROADMAP.md) which outlines the planned development of this spec.
 2. See [Agendas](working-group/agendas) for upcoming meetings of the GraphQL-over-HTTP working group.  Given our world-wide span over many timezones, we are doing an experiment of attempting to advance the spec with fewer meetings and more asynchronous communication.  During this experiment, please reach out over slack and github.
 3. Add yourself to `List of Developers` below.
-4. Find our working group on the [GraphQL Foundation slack community](https://graphql-slack.herokuapp.com/) in the [graphql-over-http channel](https://graphql.slack.com/archives/CRTKLUZRT).
+4. Find our working group on the [GraphQL Foundation slack community](https://slack.graphql.org) in the [graphql-over-http channel](https://graphql.slack.com/archives/CRTKLUZRT).
 
 ## List of Developers
 

--- a/INTERESTED_DEVELOPERS.md
+++ b/INTERESTED_DEVELOPERS.md
@@ -5,7 +5,7 @@
 If you're interested in this spec and helping contribute to it, you can get involved with the following steps:
 
 1. Read the [Roadmap](ROADMAP.md) which outlines the planned development of this spec.
-2. See [Agendas](working-group/agendas) for upcoming meetings of the GraphQL-over-HTTP working group.
+2. See [Agendas](working-group/agendas) for upcoming meetings of the GraphQL-over-HTTP working group.  Given our world-wide span over many timezones, we are doing an experiment of attempting to advance the spec with fewer meetings and more asynchronous communication.  During this experiment, please reach out over slack and github.
 3. Add yourself to `List of Developers` below.
 4. Find our working group on the [GraphQL Foundation slack community](https://graphql-slack.herokuapp.com/) in the [graphql-over-http channel](https://graphql.slack.com/archives/CRTKLUZRT).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > 
 > This spec is in a preliminary stage of active development, and can change a lot before reaching `Draft` stage.  For more information, please see the [Roadmap](ROADMAP.md) or [how to get involved](INTERESTED_DEVELOPERS.md).
 >
-> You can find our community in the [graphql-over-http channel](https://graphql.slack.com/archives/CRTKLUZRT) on the [GraphQL Foundation slack](https://graphql-slack.herokuapp.com/).
+> You can find our community in the [graphql-over-http channel](https://graphql.slack.com/archives/CRTKLUZRT) on the [GraphQL Foundation slack](https://slack.graphql.org).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-> **Stage 1: Proposal** 
+> **Stage 0: Preliminary**
 > 
-> This spec is under active development. For more information, please see the [Roadmap](ROADMAP.md) or [how to get involved](INTERESTED_DEVELOPERS.md).
+> This spec is in a preliminary stage of active development, and can change a lot before reaching `Draft` stage.  For more information, please see the [Roadmap](ROADMAP.md) or [how to get involved](INTERESTED_DEVELOPERS.md).
 >
 > You can find our community in the [graphql-over-http channel](https://graphql.slack.com/archives/CRTKLUZRT) on the [GraphQL Foundation slack](https://graphql-slack.herokuapp.com/).
 
@@ -26,3 +26,7 @@ and server implementations.
 The GraphQL over HTTP specification is edited in the [spec-md markdown file](./spec/GraphQLOverHTTP.md).
 
 In the future, we plan that you would be able to view the generated form of the specification as well.
+
+---
+Copyright Joint Development Foundation Projects, LLC, GraphQL Series.<br>
+[graphql.org](https://graphql.org) | [Spec](https://spec.graphql.org) | [GitHub](https://github.com/graphql/graphql-over-http) | [GraphQL Foundation](https://foundation.graphql.org) | [Code of Conduct](https://code-of-conduct.graphql.org) | [Slack](https://graphql.slack.com/archives/CRTKLUZRT) | [Store](https://store.graphql.org)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,10 @@ _Provide a specification that allows GraphQL clients and servers with different 
 
 ## Version 1.0
 
-We intend 1.0 of the spec to establish and codify existing common usages of GraphQL over HTTP. In layout and structure it should lay a foundation for future development and standardization. However, we intend to see no major new features or standards emerging in this version. 
+After significant meetings, the Working Group has come to consensus that a first version of this spec should
+introduce some key changes over the prior existing uses of GraphQL over HTTP.
+This first version _might_ also codify existing prior common usages of GraphQL over HTTP.
+In layout and structure version 1.0 should lay a foundation for future development and standardization.
 
 ### Scope
 
@@ -46,3 +49,36 @@ Future versions of the spec may include these concepts:
 - Multipart requests (file uploads)
 - Submit MIME type application/graphql+json to IANA
 - New HTTP SEARCH method and how it could be used https://tools.ietf.org/html/draft-snell-search-method-01
+
+## Stages
+
+The process of writing this specification may proceed according this rough outline of stages.
+We are currently in the *Preliminary Stage*.
+
+### Stage 0: Preliminary
+
+In the *Preliminary Stage*, things may change rapidly and no one should count on any particular
+detail remaining the same.
+
+- If a PR has no requests for changes for 2 weeks then it should be merged by one of the maintainers
+- If anyone has an objection later, they just open a PR to make the change and it goes through the same process
+- Optional: When there is lots of consensus but not 100% full consensus then:
+   - We might merge the consensus-view and debate modifying it in parallel
+   - Anyone can extract the non-controversial part and make a separate PR
+
+When the spec seems stable enough, the working group would promote it to *Proposal Stage*.
+
+### Stage 1: Proposal
+
+In the *Proposal Stage*, things can still change but it is reasonable to start implementations.
+
+- Before release of the spec, in "Draft" stage, we have to review the spec and review all open PRs
+- Every merge to master would need strong consensus
+- Only changes that address concerns
+- Implementers could start trying things
+
+After the spec and open PRs are reviewed and there is strong consensus, the working group would promote it to *Draft Stage*.
+
+### Stage 2: Draft
+
+This corresponds to the general [GraphQL Draft Stage](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md#stage-2-draft)

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -1,9 +1,9 @@
 GraphQL Over HTTP
 -----------------
 
-Note: **Stage 1: Proposal** 
-This spec is under active development. For more information, please see the [Roadmap](https://github.com/APIs-guru/graphql-over-http/blob/master/ROADMAP.md) or [how to get involved](https://github.com/APIs-guru/graphql-over-http/blob/master/INTERESTED_DEVELOPERS.md).
-You can find our community in the [graphql-over-http channel](https://graphql.slack.com/archives/CRTKLUZRT) on the [GraphQL Foundation slack](https://graphql-slack.herokuapp.com/).
+Note: **Stage 0: Preliminary**
+This spec is under active development, and not ready for implementations yet. For more information, please see the [Roadmap](https://github.com/APIs-guru/graphql-over-http/blob/master/ROADMAP.md) or [how to get involved](https://github.com/APIs-guru/graphql-over-http/blob/master/INTERESTED_DEVELOPERS.md).
+You can find our community in the [graphql-over-http channel](https://graphql.slack.com/archives/CRTKLUZRT) on the [GraphQL Foundation slack](https://slack.graphql.org).
 
 ---
 

--- a/working-group/README.md
+++ b/working-group/README.md
@@ -8,4 +8,4 @@ The GraphQL over HTTP working group is a sub group of the GraphQL working group.
 
 See [Agendas](agendas) for upcoming scheduled meetings and notes from previous meetings.
 
-*December 2020 Update:  Given our world-wide span over many timezones, we are doing an experiment of attempting to advance the spec with fewer meetings, using asynchronous communication.  During this experiment, please reach out over slack and github.*
+*December 2020 Update:  Given our world-wide span over many time-zones, we are doing an experiment of attempting to advance the spec with fewer meetings, using asynchronous communication.  During this experiment, please reach out over Slack and GitHub.*

--- a/working-group/README.md
+++ b/working-group/README.md
@@ -8,3 +8,4 @@ The GraphQL over HTTP working group is a sub group of the GraphQL working group.
 
 See [Agendas](agendas) for upcoming scheduled meetings and notes from previous meetings.
 
+*December 2020 Update:  Given our world-wide span over many timezones, we are doing an experiment of attempting to advance the spec with fewer meetings, using asynchronous communication.  During this experiment, please reach out over slack and github.*


### PR DESCRIPTION
Issue: https://github.com/graphql/graphql-over-http/issues/148
Updates include:
- Spec is in Preliminary Phase, with more frequent updates allowed.
- Working Group is using asynchronous communication.
- Spec is making changes to status-quo usage.
- Added GraphQL Foundation requested footer to README.
  (with GraphQL-over-HTTP specific links)