### PR TITLE
remove subscriptions from allowed POST operations

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -194,7 +194,7 @@ GET requests MUST NOT be used for executing mutation operations. If the values o
 
 ## POST
 
-A GraphQL POST request instructs the server to perform a query, mutation or subscription operation. A GraphQL POST request MUST have a body which contains values of the request parameters encoded according to the value of `Content-Type` header of the request.
+A GraphQL POST request instructs the server to perform a query or mutation operation. A GraphQL POST request MUST have a body which contains values of the request parameters encoded according to the value of `Content-Type` header of the request.
 
 A client MUST include a `Content-Type` with a POST request.
 


### PR DESCRIPTION
When executing a subscription operation a client expects multiple results which can best be expressed as a stream, while the incremental delivery RFC could be misused for describing how a stream of subscription events can be delivered to clients, it is clearly not the correct fit, as multipart requests are intended to be short-lived, while subscriptions could stay active for longer periods of time. Until alternative directions such as SSE events (as supported via graphql-helix and graphql-sse) are explored it might make sense to completely remove `subscriptions` from the list of allowed operations that can be executed via `POST`.
