### PR TITLE
Create agenda for June 27th WG

### DIFF
--- a/working-group/agendas/2022/2022-06-27.md
+++ b/working-group/agendas/2022/2022-06-27.md
@@ -1,0 +1,112 @@
+<!--
+
+Hello! You're welcome to join our subcommittee meeting and add to the agenda
+by following these three steps:
+
+   1. Add your name to the list of attendees (in alphabetical order).
+
+      - To respect meeting size, attendees should be relevant to the agenda.
+        That means we expect most who join the meeting to participate in
+        discussion. If you'd rather just watch, check out our YouTube[1].
+
+      - Please include the organization (or project) you represent, and the
+        location (including country code[2]) you expect to be located in during
+        the meeting.
+
+      - If you're willing to help take notes, add "✏️" after your name
+        (eg. Ada Lovelace ✏). This is hugely helpful!
+
+   2. If relevant, add your topic to the agenda (sorted by expected time).
+
+      - Every agenda item has four parts: 1) the topic, 2) an expected time
+        constraint, 3) who's leading the discussion, and 4) a list of any
+        relevant links (RFC docs, issues, PRs, presentations, etc). Follow the
+        format of existing agenda items.
+
+      - Know what you want to get out of the agenda topic - what feedback do you
+        need? What questions do you need answered? Are you looking for consensus
+        or just directional feedback?
+
+      - If your topic is a new proposal it's likely an "RFC 0"[3]. The barrier
+        of entry for documenting new proposals is intentionally low, writing a
+        few sentences about the problem you're trying to solve and the rough
+        shape of your proposed solution is normally sufficient.
+
+        You can create a link for this:
+          - As an issue against this repo.
+          - As a GitHub discussion in this repo.
+          - As an RFC document into the rfcs/ folder of this repo.
+
+   3. Review our guidelines and agree to our Spec Membership & CLA.
+
+      - Review and understand our Spec Membership Agreement, Participation &
+        Contribution Guidelines, and Code of Conduct. You'll find links to these
+        in the first agenda item of every meeting.
+
+      - If this is your first time, our bot will comment on your Pull Request
+        with a link to our Spec Membership & CLA. Please follow along and agree
+        before your PR is merged.
+
+        Your organization may sign this for all of its members. To set this up,
+        please ask operations@graphql.org.
+
+PLEASE TAKE NOTE:
+
+  - By joining this meeting you must agree to the Specification Membership
+    Agreement and Code of Conduct.
+
+  - Meetings are recorded and made available on YouTube[1], by joining you
+    consent to being recorded.
+
+[1] Youtube: https://www.youtube.com/channel/UCERcwLeheOXp_u61jEXxHMA
+[2] Country codes: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes
+[3] RFC stages: https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#rfc-contribution-stages
+
+-->
+
+| This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
+| ---------------------------------------------------------------------------------------- |
+
+# GraphQL-over-HTTP WG – June 2022
+
+To read about the purpose of this subcommittee, please see
+[the README](../../README.md).
+
+This is an open meeting in which anyone in the GraphQL community may attend.
+
+- **Date & Time**: [Monday 27th June at 17:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=6&day=27&hour=17&min=0&sec=0&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604)
+  - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
+  - _Please Note:_ The date or time may change. Please check this agenda the
+    week of the meeting to confirm. While we try to keep all calendars accurate,
+    this agenda document is the source of truth.
+- **Video Conference Link**: https://zoom.us/j/595593013
+  - _Password:_ TBD
+- **Live Notes**: [Google Doc](https://docs.google.com/document/d/1UKY4vBpJwk5f_tcWrhZZv8-Ogb8g0F8zOWrLVahTmqQ/edit?usp=sharing)
+
+[calendar]:
+  https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
+[google calendar]:
+  https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[ical file]:
+  https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
+
+## Attendees
+
+<!-- prettier-ignore -->
+Name                    | GitHub                 | Organization           | Location
+----------------------- | ---------------------- | ---------------------- | --------------------------
+Benjie Gillam           | @Benjie                | Graphile               | Southampton, UK
+
+## Agenda
+
+1. Agree to Membership Agreement, Participation & Contribution Guidelines and
+   Code of Conduct (1m, Organizer)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+   - [Contribution Guide](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Organizer)
+1. Determine volunteers for note taking (1m, Organizer)
+1. Review agenda (2m, Organizer)
+1. Review previous meeting's action items (5m, Organizer)
+


### PR DESCRIPTION
The next meeting of the GraphQL-over-HTTP working group has been scheduled, please add yourself to the agenda if you intend to attend.

Fixes #177