### PR TITLE
Split 'invalid request body or parsing failure' into three examples

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -537,17 +537,34 @@ The following examples provide guidance on how to deal with specific error cases
 when using the `application/graphql+json` media type to encode the response
 body:
 
-##### Invalid parameters or parsing failure
+##### JSON parsing failure
 
-For example a POST response body of `NONSENSE` or `{"qeury": "{__typena`.
+For example a POST response body of `NONSENSE` or `{"query":` (note: invalid
+JSON).
 
-Requests that do not constitute a well-formed GraphQL request should result in
-status code `400` (Bad Request).
+Requests that the server cannot interpret should result in status code `400`
+(Bad Request).
+
+##### Invalid parameters
+
+For example a POST response body of `{"qeury": "{__typename}"}` (note: typo) or
+`{"query": "query Q ($i:Int!) { q(i: $i) }", "variables": [7]}` (note: invalid
+shape for `variables`).
+
+Requests that do not constitute a well-formed _GraphQL-over-HTTP request_ should
+result in status code `400` (Bad Request).
+
+##### Document parsing failure
+
+For example a POST response body of `{"query": "{"}`.
+
+Requests where the _GraphQL document_ cannot be parsed should result in status
+code `400` (Bad Request).
 
 ##### Document validation failure
 
-Requests that fail to pass validation SHOULD be denied execution with a status
-code of `400` (Bad Request).
+Requests that fail to pass _GraphQL validation_ SHOULD be denied execution with
+a status code of `400` (Bad Request).
 
 Note: In certain circumstances, for example persisted operations that were
 previously known to be valid, the server MAY attempt execution regardless of

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -539,7 +539,7 @@ body:
 
 ##### JSON parsing failure
 
-For example a POST response body of `NONSENSE` or `{"query":` (note: invalid
+For example a POST request body of `NONSENSE` or `{"query":` (note: invalid
 JSON).
 
 Requests that the server cannot interpret should result in status code `400`
@@ -547,7 +547,7 @@ Requests that the server cannot interpret should result in status code `400`
 
 ##### Invalid parameters
 
-For example a POST response body of `{"qeury": "{__typename}"}` (note: typo) or
+For example a POST request body of `{"qeury": "{__typename}"}` (note: typo) or
 `{"query": "query Q ($i:Int!) { q(i: $i) }", "variables": [7]}` (note: invalid
 shape for `variables`).
 

--- a/spec/metadata.json
+++ b/spec/metadata.json
@@ -6,7 +6,9 @@
       "graphql-request": "#request",
       "graphql-response": "#sec-Response",
       "graphql-request-error": "#sec-Errors.Request-errors",
-      "graphql-field-error": "#sec-Errors.Field-errors"
+      "graphql-field-error": "#sec-Errors.Field-errors",
+      "graphql-document": "#sec-Document",
+      "graphql-validation": "#sec-Validation"
     }
   }
 }


### PR DESCRIPTION
Following @glasser's feedback here https://github.com/graphql/graphql-over-http/pull/175#discussion_r917079660 I've split the "Invalid request body or parsing failure" example into three separate examples, and added spec-md references.

I believe this change does not include any normative changes, it's purely editorial.

Incidentally these H5's are horrible:

https://graphql.github.io/graphql-over-http/draft/#sec-Operation-cannot-be-determined

> [6.4.2.1.3](https://graphql.github.io/graphql-over-http/draft/#sec-Operation-cannot-be-determined) Operation cannot be determined

We should probably hoist to a higher level somewhere? (In a separate PR.)