### PR TITLE
IncrementalDelivery: clarify exactly where CRLF is

### DIFF
--- a/rfcs/IncrementalDelivery.md
+++ b/rfcs/IncrementalDelivery.md
@@ -17,6 +17,7 @@ The HTTP response for an incrementally delivered response should conform to the 
 An example response body will look like:
 
 ```
+
 ---
 Content-Type: application/json; charset=utf-8
 
@@ -28,11 +29,10 @@ Content-Type: application/json; charset=utf-8
 -----
 ```
 * The boundary used is `-` and is passed to the client in the http response's `Content-Type` header. Note that headers can appear in both the HTTP response itself and as part of the response body. The `Content-Type` header must be sent in the HTTP response.
-* An initial boundary is sent marking the end of the preamble area.
+* Before each part of the multi-part response, a boundary (`CRLF`, `---`, `CRLF`) is sent.
 * Each part of the multipart response must contain a `Content-Type` header. Similar to the GraphQL specification this specification does not require a specific serialization format. For consistency and ease of notation, examples of the response are given in JSON throughout the spec.
-* After all headers, an additional `CRLF` is sent.
-* The payload is sent, followed by a `CRLF`.
-* After each payload, a boundary is sent. For the final payload, the terminating boundary of `-----` followed by a `CRLF` is sent. For all other payloads a boundary of `---` followed by a `CRFL` is sent.
+* After all headers for each part, an additional `CRLF` is sent, followed by the payload for the part.
+* After the final payload, the terminating boundary of `CRLF` followed by `-----` followed by `CRLF` is sent.
 
 ## Server Implementations
 * `express-graphql`: [pull request](https://github.com/graphql/express-graphql/pull/583)


### PR DESCRIPTION
According to RFC 1341, there is a CRLF *before* each `--BOUNDARY`, and *before* each payload chunk. That implies there should be a CRLF at the very beginning of the body before the first `--BOUNDARY`. (It also implies that if (as shown in the example) there is no blank link between each JSON chunk and the boundary after it, then the part should not be regarded as containing a trailing newline.)