### PR TITLE
Server can choose the media type on Accept fail

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -445,7 +445,7 @@ in the `Accept` HTTP header, the server MUST either:
 
 1. Disregard the `Accept` header and respond with the server's choice of media
    type, indicating this in the `Content-Type` header; OR
-3. Respond with a `406 Not Acceptable` status code and stop processing the
+2. Respond with a `406 Not Acceptable` status code and stop processing the
    request.
 
 A server MUST support any _GraphQL-over-HTTP request_ which accepts the

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -443,10 +443,15 @@ In alignment with the
 specification, when a client does not include at least one supported media type
 in the `Accept` HTTP header, the server MUST either:
 
-1. Disregard the `Accept` header and respond with the server's choice of media
-   type, indicating this in the `Content-Type` header; OR
-2. Respond with a `406 Not Acceptable` status code and stop processing the
-   request.
+1. Respond with a `406 Not Acceptable` status code and stop processing the
+   request (RECOMMENDED); OR
+2. Disregard the `Accept` header and respond with the server's choice of media
+   type (NOT RECOMMENDED).
+
+Note: It is unlikely that a client can process a response that does not match
+one of the media types it has requested, hence `406 Not Acceptable` being the
+recommended response. However, the server authors may know better about the
+specific clients consuming their endpoint, thus both approaches are permitted.
 
 A server MUST support any _GraphQL-over-HTTP request_ which accepts the
 `application/json` media type (as indicated by the `Accept` header).

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -443,9 +443,9 @@ In alignment with the
 specification, when a client does not include at least one supported media type
 in the `Accept` HTTP header, the server MUST either:
 
-1. Disregard the `Accept` header and respond with the default media type of
-   `application/json`, specifying this in the `Content-Type` header; OR
-2. Respond with a `406 Not Acceptable` status code and stop processing the
+1. Disregard the `Accept` header and respond with the server's choice of media
+   type, indicating this in the `Content-Type` header; OR
+3. Respond with a `406 Not Acceptable` status code and stop processing the
    request.
 
 A server MUST support any _GraphQL-over-HTTP request_ which accepts the


### PR DESCRIPTION
If the client issues `Accept: application/graphql-response+json, application/json` and the server does not support this for the request (e.g. the request uses `@stream`/`@defer` so needs a multipart response) then the server should be able to choose to respond with another suitable media type, for example `multipart/mixed;type=application/graphql-response+json`. Thanks to @michaelstaib for pointing out this oversight.

(Note: v1 doesn't explicitly specify `@stream`/`@defer` or `subscription` related concerns, but we should still be future proof where possible.)