### PR TITLE
[GraphQL over WS] Allow null payloads

### DIFF
--- a/rfcs/GraphQLOverWebSocket.md
+++ b/rfcs/GraphQLOverWebSocket.md
@@ -37,7 +37,7 @@ If the server receives more than one `ConnectionInit` message at any given time,
 ```typescript
 interface ConnectionInitMessage {
   type: 'connection_init';
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
 }
 ```
 
@@ -52,7 +52,7 @@ The server can use the optional `payload` field to transfer additional details a
 ```typescript
 interface ConnectionAckMessage {
   type: 'connection_ack';
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
 }
 ```
 
@@ -73,7 +73,7 @@ The optional `payload` field can be used to transfer additional details about th
 ```typescript
 interface PingMessage {
   type: 'ping';
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
 }
 ```
 
@@ -90,7 +90,7 @@ The optional `payload` field can be used to transfer additional details about th
 ```typescript
 interface PongMessage {
   type: 'pong';
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
 }
 ```
 


### PR DESCRIPTION
https://github.com/enisdenjo/graphql-ws/pull/456

Original thinking was to support keeping the message size small by completely omitting the payload if nullish. But, that was an unnecessary limiting optimization.

Furthermore, allowing null values also keeps the spec more in line with the GraphQL over HTTP spec.

> Specifying `null` in JSON (or equivalent values in other formats) as values for optional request parameters is equivalent to not specifying them at all.

[_GraphQL over HTTP spec_](https://graphql.github.io/graphql-over-http/draft/)