### PR TITLE
Indicate the WG test suite doc is out of date.

### DIFF
--- a/working-group/test-suite.md
+++ b/working-group/test-suite.md
@@ -1,3 +1,5 @@
+🚨 **WARNING** 🚨 This proposed test suite is out of date and does not reflect the current status of the spec. For a more up to date test suite, please see [graphql-http audits](https://github.com/graphql/graphql-http#audits) or the testing tool at [graphql-http.com](https://graphql-http.com/). This document only exists for historical reasons.
+
 # Automated Test Suite
 
 > These are the descriptions of the tests that we intend to build. This document is a scaffold until we have the tests implemented. At that point, the code itself will become the documentation and this document will be removed.


### PR DESCRIPTION
The `working-group/test-suite.md` document was a collection of our ideas around testing for an earlier version of the spec. It hasn't been touched in 3 years and the spec itself has evolved a lot since then, and its existence is causing confusion. This PR puts a notice at the top of the document to make it clear that it is out of date.

Fixes #246