### PR TITLE
Expand persisted operations discussion time

### DIFF
--- a/working-group/agendas/2023/2023-10-26.md
+++ b/working-group/agendas/2023/2023-10-26.md
@@ -113,6 +113,6 @@ Denis Badurina          | @enisdenjo             | The Guild               | Sar
 1. Determine volunteers for note taking (1m, Organizer)
 1. Review agenda (2m, Organizer)
 1. Review previous meeting's action items (5m, Organizer)
-1. Review persisted operations RFC (10m, @JoviDeCroock)
 1. ["Accept" header PR](https://github.com/graphql/graphql-over-http/pull/227) decision (15m, Benjie)
+1. Review persisted operations RFC (25m, @JoviDeCroock)
 1. Advancing the spec to stage 2 (remaining time, Benjie)


### PR DESCRIPTION
I've expanded the time to discuss persisted operations to enable discussing the spec edits in #264. Since it's now a bit longer, I've moved it after the 15 minute discussion so we can get that one out of the way first.

cc @JoviDeCroock 