### PR TITLE
Advance spec to Stage 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-> **Stage 1: Proposal**
+> **Stage 2: Draft**
 >
-> This spec is in the proposal stage of active development, and can change
-> before reaching `Draft` stage. For more information, please see the
-> [Roadmap](ROADMAP.md) or [how to get involved](INTERESTED_DEVELOPERS.md).
+> This spec is in the draft stage of development, and can change before reaching
+> `Accepted` stage. For more information, please see the [Roadmap](ROADMAP.md)
+> or [how to get involved](INTERESTED_DEVELOPERS.md).
 >
 > You can find our community in the
 > [graphql-over-http channel](https://discord.com/channels/625400653321076807/863141924126588958)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ Future versions of the spec may include these concepts:
 ## Stages
 
 The process of writing this specification may proceed according this rough
-outline of stages. We are currently in the _Proposal Stage_.
+outline of stages. We are currently in the _Draft Stage_.
 
 ### Stage 0: Preliminary
 
@@ -93,7 +93,7 @@ implementations.
 
 - Before release of the spec, in "Draft" stage, we have to review the spec and
   review all open PRs
-- Every merge to master would need strong consensus
+- Every merge to main would need strong consensus
 - Only changes that address concerns
 - Implementers could start trying things
 
@@ -103,4 +103,9 @@ working group would promote it to _Draft Stage_.
 ### Stage 2: Draft
 
 This corresponds to the general
-[GraphQL Draft Stage](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md#stage-2-draft)
+[GraphQL Draft Stage](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-2-draft)
+
+### Stage 3: Accepted
+
+This corresponds to the general
+[GraphQL Accepted Stage](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-3-accepted)

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -1,12 +1,9 @@
 ## GraphQL Over HTTP
 
-Note: **Stage 1: Proposal** This spec is under active development, and not ready
-for implementations yet. For more information, please see the
-[Roadmap](https://github.com/graphql/graphql-over-http/blob/master/ROADMAP.md)
-or
-[how to get involved](https://github.com/graphql/graphql-over-http/blob/master/INTERESTED_DEVELOPERS.md).
-You can find our community in the #graphql-over-http channel on the
-[GraphQL Foundation Discord](https://discord.graphql.org).
+Note: **Stage 2: Draft** &mdash; this spec is not yet official, but is now a
+fully formed solution. Drafts may continue to evolve and change, occasionally
+dramatically, and are not guaranteed to be accepted. Therefore, it is unwise to
+rely on a draft in a production GraphQL Service.
 
 ---
 


### PR DESCRIPTION
Fixes https://github.com/graphql/graphql-over-http/issues/272

The GraphQL-over-HTTP WG met yesterday and everyone is comfortable with advancing the spec to stage 2. We'll leave this PR open until the next WG to gather feedback, and if there are no major reservations expressed then we'll go ahead and advance it to stage 2 at [the November meeting](https://github.com/graphql/graphql-over-http/blob/main/working-group/agendas/2023/2023-11-23.md).

cc @abernix @balshor @benjie @deinok @erikwittern @jaydenseric @michaelstaib @mike-marcacci @mmatsa @shane32 @sjparsons @spawnia @sungam3r @touchstone117 @enisdenjo @JoviDeCroock