### PR TITLE
Make it clear that other keys are reserved

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -376,6 +376,11 @@ When encoded in JSON, a _GraphQL-over-HTTP request_ is encoded as a JSON object
   names and the values of which are the variable values
 - {extensions} - an optional object (map)
 
+All other property names are reserved for future expansion; if implementors need
+to add additional information to a request they MUST do so via other means, the
+RECOMMENDED approach is to add an implementor-scoped entry to the {extensions}
+object.
+
 ### Example
 
 If we wanted to execute the following GraphQL query:


### PR DESCRIPTION
Fixes #271

The `extensions` object exists so that vendors may add their own properties to requests/responses/errors/etc. All top-level keys are reserved by the spec. This PR makes this explicit for JSON-encoded requests.

@enisdenjo Will this break any of the existing implementations, other than Relay's persisted queries network layer recommendation?