### PR TITLE
State that additional properties are ignored

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -376,7 +376,8 @@ When encoded in JSON, a _GraphQL-over-HTTP request_ is encoded as a JSON object
 All other property names are reserved for future expansion; if implementors need
 to add additional information to a request they MUST do so via other means, the
 RECOMMENDED approach is to add an implementor-scoped entry to the {extensions}
-object.
+object. Servers receiving a request with additional properties MUST ignore the
+additional properties when processing the request.
 
 ### Example
 

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -376,8 +376,10 @@ When encoded in JSON, a _GraphQL-over-HTTP request_ is encoded as a JSON object
 All other property names are reserved for future expansion; if implementors need
 to add additional information to a request they MUST do so via other means, the
 RECOMMENDED approach is to add an implementor-scoped entry to the {extensions}
-object. Servers receiving a request with additional properties MUST ignore the
-additional properties when processing the request.
+object.
+
+Servers receiving a request with additional properties MUST ignore properties
+they do not understand.
 
 ### Example
 


### PR DESCRIPTION
> Servers don't need to validate this, and in fact they should not since a client from a future spec version may send additional keys, which legacy servers should just ignore.

I think we should add this to the spec.  The main graphql spec did not state this explicitly for reserved names (those starting with `__`), and now any current GraphQL UI applications built on Apollo's graphql library crash if they see additional reserved names in the introspection result.  (I consider this a bug but 🤷‍♂️ ).  They should be built to ignore additional features added to the spec, and the spec should state this.

We could add something like this:

_Servers receiving a request with additional properties MUST ignore the additional properties when processing the request._

_Originally posted by @Shane32 in https://github.com/graphql/graphql-over-http/issues/278#issuecomment-1912398114_
            