### PR TITLE
GraphQLOverSSE: note including an empty data field in the complete message

### DIFF
--- a/rfcs/GraphQLOverSSE.md
+++ b/rfcs/GraphQLOverSSE.md
@@ -48,6 +48,9 @@ interface CompleteMessage {
 }
 ```
 
+> [!IMPORTANT]
+> Include an empty `data: ` field when sending the message to a client that uses [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource). If the field is omitted, the complete event won't trigger the listener.
+
 ## Single connection mode
 
 > When **not used over HTTP/2**, SSE suffers from a limitation to the maximum number of open connections, which can be specially painful when opening various tabs as the limit is per browser and set to a very low number (6). The issue has been marked as "Won't fix" in [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=275955) and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=906896). This limit is per browser + domain, so that means that you can open 6 SSE connections across all of the tabs to `www.example1.com` and another 6 SSE connections to `www.example2.com`. (from [Stackoverflow](https://stackoverflow.com/a/5326159/1905229)). When using HTTP/2, the maximum number of simultaneous HTTP streams is negotiated between the server and the client (defaults to 100).


### PR DESCRIPTION
https://github.com/enisdenjo/graphql-sse/pull/71