### PR TITLE
Require support of application/graphql-response+json by servers

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -458,7 +458,7 @@ specific clients consuming their endpoint, thus both approaches are permitted.
 A server MUST support any _GraphQL-over-HTTP request_ which accepts the
 `application/json` media type (as indicated by the `Accept` header).
 
-A server SHOULD support any _GraphQL-over-HTTP request_ which accepts the
+A server MUST support any _GraphQL-over-HTTP request_ which accepts the
 `application/graphql-response+json` media type (as indicated by the `Accept`
 header).
 


### PR DESCRIPTION
As of 1/1/2025, the proposed watershed date has passed.  As the GraphQL over HTTP specification has not been released yet, eliminating the watershed period entirely may leave clients without adequate time to adjust to some of the new behaviors mandated by the specification.

This PR aims to separate the date that the server is required to support `application/graphql-response+json` from the date that it is required to be considered the default when no `Accept` header is provided.  This allows for clients to immediately take advantage of the benefits of the `application/graphql-response+json` media type for all compliant servers.

I'm suggesting that this support is required immediately.  While the original concept was that the spec would be released quickly, representing the current state of GraphQL servers, this did not occur.  However, the draft GraphQL-over-HTTP spec has been out since 2020, and has had no changes of substance (of any kind) since the addition of the `application/graphql-response+json` media type in Aug 2022.  As such, the fact that it was not "released as a spec" makes little difference.  Server implementations have had time to review and implement the new features of the draft specification, and various servers have done so.

Further, releasing the spec with this change does not break existing implementations.  They simply are not officially compliant until they support the new content type.  And finally, popular server implementations (assuming they have been watching this repository) have been expecting this change to take effect on 1/1/2025 and would expect to be non-compliant if they did not support the new content type.

So why make this change now?  I believe the sooner that all servers support the new media type, the sooner that the entire GraphQL ecosystem will adopt it.  Otherwise simple clients (e.g. handwritten with `fetch`) might not be able to use the new media type if servers are not supporting it, delaying general adoption.

This PR is complementary to pushing the watershed date further out as proposed within:
- #322 