### PR TITLE
Fix consistency of examples

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -600,7 +600,7 @@ code `200` (Okay).
 ##### Document validation failure
 
 If a request fails to pass _GraphQL validation_, the server SHOULD NOT execute
-the request and SHOULD return a status code of `400` (Bad Request).
+the request and SHOULD return a status code of `200` (Okay).
 
 ##### Operation cannot be determined
 

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -715,8 +715,8 @@ code `400` (Bad Request).
 
 ##### Document validation failure
 
-If a request fails to pass _GraphQL validation_, the server SHOULD NOT execute
-the request and SHOULD return a status code of `400` (Bad Request).
+If a request fails _GraphQL validation_, the server SHOULD return a status code
+of `400` (Bad Request) without proceeding to GraphQL execution.
 
 ##### Operation cannot be determined
 

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -599,8 +599,8 @@ code `200` (Okay).
 
 ##### Document validation failure
 
-Requests that fail to pass _GraphQL validation_, the server SHOULD NOT execute
-the request and SHOULD return a status code of `200` (Okay).
+If a request fails to pass _GraphQL validation_, the server SHOULD NOT execute
+the request and SHOULD return a status code of `400` (Bad Request).
 
 ##### Operation cannot be determined
 
@@ -715,8 +715,8 @@ code `400` (Bad Request).
 
 ##### Document validation failure
 
-Requests that fail to pass _GraphQL validation_ SHOULD be denied execution with
-a status code of `400` (Bad Request).
+If a request fails to pass _GraphQL validation_, the server SHOULD NOT execute
+the request and SHOULD return a status code of `400` (Bad Request).
 
 ##### Operation cannot be determined
 


### PR DESCRIPTION
Fix the Document Validation Failure examples to match the wording of the other examples.