### PR TITLE
Move all media types to a common section

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -424,7 +424,7 @@ properties in one of the manners described in this specification:
   [request error](https://spec.graphql.org/draft/#request-error) happened.
 - {errors} - (_Optional_, list): a list of
   [errors](https://spec.graphql.org/draft/#sec-Errors) as specified in the
-  GraphQL specification if present. Absent if no error happened. 
+  GraphQL specification if present. Absent if no error happened.
 - {extensions} - an optional object (map) reserved for implementers to extend
   the protocol however they see fit, as specified in
   [the Response section of the GraphQL specification](https://spec.graphql.org/draft/#sec-Response-Format.Response).

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -161,8 +161,6 @@ Note: Allowing other media types, particularly on requests, can be insecure.
 For consistency and ease of notation, examples of the response are given in JSON
 throughout this specification.
 
-## Media Types
-
 The following are the officially recognized GraphQL media types:
 
 | Name                                | Description                           |
@@ -178,6 +176,145 @@ encoding information and matches one of the officially recognized GraphQL media
 types, then `utf-8` MUST be assumed (e.g. for header
 `Content-Type: application/graphql-response+json`, UTF-8 encoding would be
 assumed).
+
+## `application/json` media type
+
+The `application/json` media type indicates a _GraphQL-over-HTTP request_
+encoded as a JSON object (map), with the properties specified by the
+_GraphQL-over-HTTP request_:
+
+- {query}
+- {operationName}
+- {variables}
+- {extensions}
+
+All other property names are reserved for future expansion. If implementers need
+to add additional information to a request they MUST do so via other means; the
+RECOMMENDED approach is to add an implementer-scoped entry to the {extensions}
+object.
+
+Servers receiving a request with additional properties MUST ignore properties
+they do not understand.
+
+Specifying `null` for optional request parameters is equivalent to not
+specifying them at all.
+
+### Example
+
+If we wanted to execute the following GraphQL query:
+
+```raw graphql example
+query ($id: ID!) {
+  user(id: $id) {
+    name
+  }
+}
+```
+
+With the following query variables:
+
+```json example
+{
+  "id": "QVBJcy5ndXJ1"
+}
+```
+
+This request could be sent via an HTTP POST to the relevant URL using the JSON
+encoding with the header:
+
+```headers example
+Content-Type: application/json
+```
+
+And the body:
+
+```json example
+{
+  "query": "query ($id: ID!) {\n  user(id: $id) {\n    name\n  }\n}",
+  "variables": {
+    "id": "QVBJcy5ndXJ1"
+  }
+}
+```
+
+## `application/graphql-response+json`
+
+The `application/graphql-response+json` media type indicates a
+_GraphQL-over-HTTP response_ encoded as a JSON object (map), with the properties
+specified by the _GraphQL-over-HTTP response_:
+
+- {data}
+- {errors}
+- {extensions}
+
+### Example
+
+If we wanted to execute the following GraphQL query:
+
+```raw graphql example
+query ($id: ID!) {
+  user(id: $id) {
+    name
+  }
+}
+```
+
+A successful response would contain the `application/graphql-response+json`
+header:
+
+```headers example
+Content-Type: application/graphql-response+json
+```
+
+And a body containing {data}:
+
+```json example
+{
+  "data": {
+    "user": {
+      "name": "Luke Skywalker"
+    }
+  }
+}
+```
+
+A partial response would also contain {errors}:
+
+```json example
+{
+  "data": {
+    "user": {
+      "name": null
+    }
+  },
+  "errors": [
+    {
+      "message": "An error occured resolving field 'name'",
+      "path": ["user", "name"]
+    }
+  ]
+}
+```
+
+If we wanted to send an invalid query:
+
+```raw graphql example
+query {
+  someInvalidField
+}
+```
+
+The response would not contain any {data}:
+
+```json example
+{
+  "errors": [
+    {
+      "message": "Cannot request 'someInvalidField' on type 'Query'"
+    }
+  ]
+}
+```
 
 # Request
 
@@ -337,71 +474,6 @@ encode the request body in JSON (i.e. with `Content-Type: application/json`).
 
 Note: Request encoding with media type `application/json` is supported by every
 compliant _server_.
-
-### JSON Encoding
-
-When encoded in JSON, a _GraphQL-over-HTTP request_ is encoded as a JSON object
-(map), with the properties specified by the GraphQL-over-HTTP request:
-
-- {query} - the string representation of the Source Text of the Document as
-  specified in
-  [the Language section of the GraphQL specification](https://spec.graphql.org/draft/#sec-Language).
-- {operationName} - an optional string
-- {variables} - an optional object (map), the keys of which are the variable
-  names and the values of which are the variable values
-- {extensions} - an optional object (map) reserved for implementers to extend
-  the protocol however they see fit, as specified in
-  [the Response section of the GraphQL specification](https://spec.graphql.org/draft/#sec-Response-Format.Response).
-
-All other property names are reserved for future expansion. If implementers need
-to add additional information to a request they MUST do so via other means; the
-RECOMMENDED approach is to add an implementer-scoped entry to the {extensions}
-object.
-
-Servers receiving a request with additional properties MUST ignore properties
-they do not understand.
-
-Specifying `null` for optional request parameters is equivalent to not
-specifying them at all.
-
-### Example
-
-If we wanted to execute the following GraphQL query:
-
-```raw graphql example
-query ($id: ID!) {
-  user(id: $id) {
-    name
-  }
-}
-```
-
-With the following query variables:
-
-```json example
-{
-  "id": "QVBJcy5ndXJ1"
-}
-```
-
-This request could be sent via an HTTP POST to the relevant URL using the JSON
-encoding with the headers:
-
-```headers example
-Content-Type: application/json
-Accept: application/graphql-response+json
-```
-
-And the body:
-
-```json example
-{
-  "query": "query ($id: ID!) {\n  user(id: $id) {\n    name\n  }\n}",
-  "variables": {
-    "id": "QVBJcy5ndXJ1"
-  }
-}
-```
 
 # Response
 

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -184,7 +184,7 @@ assumed).
 A server MUST accept POST requests, and MAY accept other HTTP methods, such as
 GET.
 
-## Request Parameters
+## GraphQL-over-HTTP request
 
 :: A _GraphQL-over-HTTP request_ is an HTTP request that encodes the following
 parameters in one of the manners described in this specification:
@@ -406,17 +406,45 @@ And the body:
 # Response
 
 When a server receives a well-formed _GraphQL-over-HTTP request_, it must return
-a well‐formed _GraphQL response_. The server's response describes the result of
-validating and executing the requested operation if successful, and describes
-any errors encountered during the request.
+a well‐formed _GraphQL-over-HTTP response_. The server's response describes the
+result of validating and executing the requested operation if successful, and
+describes any errors encountered during the request.
 
 A server must comply with
 [IETF RFC 9110](https://httpwg.org/specs/rfc9110.html).
 
+## GraphQL-over-HTTP response
+
+:: A _GraphQL-over-HTTP response_ is an HTTP response that encodes the following
+properties in one of the manners described in this specification:
+
+- {data} - (_Optional_, _Nullable_, map): the result of the execution of the
+  requested operation if present. That result may be null if execution errors
+  prevented the formation of data. Absent when a
+  [request error](https://spec.graphql.org/draft/#request-error) happened.
+- {errors} - (_Optional_, list): a list of
+  [errors](https://spec.graphql.org/draft/#sec-Errors) as specified in the
+  GraphQL specification if present. Absent if no error happened. Document to
+  execute.
+- {extensions} - an optional object (map) reserved for implementers to extend
+  the protocol however they see fit, as specified in
+  [the Response section of the GraphQL specification](https://spec.graphql.org/draft/#sec-Response-Format.Response).
+
+Note: There are no circumstances where the GraphQL specification allows for a
+response having data absent without errors being present.
+
+Note: When comparing _GraphQL-over-HTTP request_ against the term
+["response"](https://spec.graphql.org/draft/#response) in the GraphQL
+specification you should note that a _GraphQL-over-HTTP response_ is either an
+[Execution Result](https://spec.graphql.org/draft/#execution-result) or a
+[Request Error Result](https://spec.graphql.org/draft/#sec-Request-Error-Result)
+but never a
+[Response Stream](https://spec.graphql.org/draft/#sec-Response-Format.Response-Stream).
+
 ## Body
 
-The body of the server's response MUST follow the requirements for a _GraphQL
-response_, encoded directly in the chosen media type.
+The body of the server's response MUST follow the requirements for a
+_GraphQL-over-HTTP response_, encoded according to the chosen media type.
 
 A server MUST indicate the media type of the response with a `Content-Type`
 header, and SHOULD indicate the encoding (e.g.
@@ -493,46 +521,48 @@ execution regardless of validation errors.
 ## Status Codes
 
 Clients should process a response using the `application/graphql-response+json`
-media type as a well-formed _GraphQL response_ independent of the HTTP status
-code.
+media type as a well-formed _GraphQL-over-HTTP response_ independent of the HTTP
+status code.
 
 Note: With `application/graphql-response+json`, clients know the response is
 well-formed and should determine the detailed status of the response from the
 response body alone, allowing server authors to adopt more appropriate status
 codes without impacting behavior of existing clients. Intermediary servers and
-services may use the status code to determine the status of the _GraphQL
-response_ without needing to process the response body; this is useful in
-request logs, developer tooling, anomaly and intrusion detection, metrics and
-observability, API gateways, and more.
+services may use the status code to determine the status of the
+_GraphQL-over-HTTP response_ without needing to process the response body; this
+is useful in request logs, developer tooling, anomaly and intrusion detection,
+metrics and observability, API gateways, and more.
 
 In case of errors that completely prevent the generation of a well-formed
-_GraphQL response_, the server SHOULD respond with the appropriate HTTP `4xx` or
-`5xx` status code depending on the concrete error condition, and MUST NOT use
-the `application/graphql-response+json` media type.
+_GraphQL-over-HTTP response_, the server SHOULD respond with the appropriate
+HTTP `4xx` or `5xx` status code depending on the concrete error condition, and
+MUST NOT use the `application/graphql-response+json` media type.
 
-If the _GraphQL response_ contains the {data} entry and it is not {null}, then
-the server MUST reply with a `2xx` status code.
+If the _GraphQL-over-HTTP response_ contains the {data} entry and it is not
+{null}, then the server MUST reply with a `2xx` status code.
 
-If the _GraphQL response_ contains the {data} entry and does not contain the
-{errors} entry, then the server SHOULD reply with a `200` status code.
+If the _GraphQL-over-HTTP response_ contains the {data} entry and does not
+contain the {errors} entry, then the server SHOULD reply with a `200` status
+code.
 
 Note: There are no circumstances where the GraphQL specification allows for a
 response having {data} as {null} without {errors} being present.
 
-If the _GraphQL response_ contains both the {data} entry (even if it is {null})
-and the {errors} entry, then the server SHOULD reply with a `294` status code.
+If the _GraphQL-over-HTTP response_ contains both the {data} entry (even if it
+is {null}) and the {errors} entry, then the server SHOULD reply with a `294`
+status code.
 
 Note: The result of executing a GraphQL operation may contain partial data as
 well as encountered errors. Errors that happen during execution of the GraphQL
 operation typically become part of the result, as long as the server is still
-able to produce a well-formed _GraphQL response_. For details of why status code
-`294` is recommended, see [Partial success](#sec-Partial-success). Using `4xx`
-and `5xx` status codes in this situation is not appropriate: since no _GraphQL
-request error_ has occurred it is seen as a "partial response" or "partial
-success".
+able to produce a well-formed _GraphQL-over-HTTP response_. For details of why
+status code `294` is recommended, see [Partial success](#sec-Partial-success).
+Using `4xx` and `5xx` status codes in this situation is not appropriate: since
+no _GraphQL request error_ has occurred it is seen as a "partial response" or
+"partial success".
 
-If the _GraphQL response_ does not contain the {data} entry then the server MUST
-reply with an appropriate `4xx` or `5xx` status code:
+If the _GraphQL-over-HTTP response_ does not contain the {data} entry then the
+server MUST reply with an appropriate `4xx` or `5xx` status code:
 
 - If the failure is due to an issue in the request itself, the appropriate `4xx`
   status code should be used:
@@ -574,8 +604,8 @@ reply with an appropriate `4xx` or `5xx` status code:
   RECOMMENDED.
 
 Note: The GraphQL specification indicates that the only situation in which the
-_GraphQL response_ does not include the {data} entry is one in which the
-{errors} entry is populated.
+_GraphQL-over-HTTP response_ does not include the {data} entry is one in which
+the {errors} entry is populated.
 
 ### Examples
 
@@ -654,7 +684,7 @@ used.
 The result of executing a GraphQL operation may contain partial data as well as
 encountered errors. Errors that happen during execution of the GraphQL operation
 typically become part of the result, as long as the server is still able to
-produce a well-formed _GraphQL response_.
+produce a well-formed _GraphQL-over-HTTP response_.
 
 Using `4xx` and `5xx` status codes when {data} is present and non-null is not
 appropriate; since no _GraphQL request error_ has occurred it is seen as a

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -433,7 +433,7 @@ properties in one of the manners described in this specification:
 Note: There are no circumstances where the GraphQL specification allows for a
 response having data absent without errors being present.
 
-Note: When comparing _GraphQL-over-HTTP request_ against the term
+Note: When comparing _GraphQL-over-HTTP response_ against the term
 ["response"](https://spec.graphql.org/draft/#response) in the GraphQL
 specification you should note that a _GraphQL-over-HTTP response_ is either an
 [Execution Result](https://spec.graphql.org/draft/#execution-result) or a

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -424,8 +424,7 @@ properties in one of the manners described in this specification:
   [request error](https://spec.graphql.org/draft/#request-error) happened.
 - {errors} - (_Optional_, list): a list of
   [errors](https://spec.graphql.org/draft/#sec-Errors) as specified in the
-  GraphQL specification if present. Absent if no error happened. Document to
-  execute.
+  GraphQL specification if present. Absent if no error happened. 
 - {extensions} - an optional object (map) reserved for implementers to extend
   the protocol however they see fit, as specified in
   [the Response section of the GraphQL specification](https://spec.graphql.org/draft/#sec-Response-Format.Response).

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -149,7 +149,7 @@ http://product.example.com/graphql
 http://example.com/product/graphql
 ```
 
-# Serialization Format
+# Media types
 
 The GraphQL specification allows for many
 [serialization formats to be implemented](https://spec.graphql.org/draft/#sec-Serialization-Format).
@@ -167,9 +167,6 @@ The following are the officially recognized GraphQL media types:
 | ----------------------------------- | ------------------------------------- |
 | `application/json`                  | Media type for GraphQL JSON requests  |
 | `application/graphql-response+json` | Media type for GraphQL JSON responses |
-
-For details of the shapes of these JSON payloads, please see
-[Request](#sec-Request) and [Response](#sec-Response).
 
 If the media type in a `Content-Type` or `Accept` header does not include
 encoding information and matches one of the officially recognized GraphQL media


### PR DESCRIPTION
Opening as draft because this is prep work for introducing new media types. This PR depends on https://github.com/graphql/graphql-over-http/pull/423. No need to include in the Sep. release, it's editorial only.

Next step: 

* introduce `application/graphql-request+json`
* rebase the `QUERY` PR to use `application/graphql-request+json`